### PR TITLE
Add jQuery dependency on header assets

### DIFF
--- a/src/inc/assets.php
+++ b/src/inc/assets.php
@@ -8,7 +8,7 @@ function voidx_assets_header() {
 
   // Header script loading is simplistic in this starter kit but you may want to change what file is loaded based on various conditions; check out the footer asset loader for an example
   $file = 'x-header';
-  wp_enqueue_script( 'voidx-header', get_stylesheet_directory_uri() . '/js/' . $file . '.js', $deps = array(), filemtime( get_template_directory() . '/js/' . $file . '.js' ), false );
+  wp_enqueue_script( 'voidx-header', get_stylesheet_directory_uri() . '/js/' . $file . '.js', $deps = array('jquery'), filemtime( get_template_directory() . '/js/' . $file . '.js' ), false );
 
   // Register and enqueue our main stylesheet with versioning based on last modified time
   wp_register_style( 'voidx-style', get_stylesheet_uri(), $dependencies = array(), filemtime( get_template_directory() . '/style.css' ) );


### PR DESCRIPTION
Included sample `header.js` file depends on jQuery, but it's not explicitly set on the `wq_enqueue_script` call