### PR TITLE
Remove 'setup' dependency on 'utils-wipe'

### DIFF
--- a/gulpfile.js/tasks/utils.js
+++ b/gulpfile.js/tasks/utils.js
@@ -6,7 +6,7 @@ var gulp        = require('gulp'),
     config      = require('../../gulpconfig').utils;
 
 // Totally wipe the contents of the `dist` folder to prepare for a clean build; additionally trigger Bower-related tasks to ensure we have the latest source files
-gulp.task('utils-wipe', ['setup'], function() {
+gulp.task('utils-wipe', function() {
   return del(config.wipe);
 });
 


### PR DESCRIPTION
There is no 'setup' task anymore, so `gulp dist` fails because it depends on `utils-wipe`. This removes the dependency.